### PR TITLE
revert domain name

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -16,7 +16,7 @@ permissions:
 
 # set an environment variable for use in all the jobs pointing the site_url
 env:
-  site_url: https://edf.bean-recordings.com
+  site_url: https://edf.birki.io
 
 jobs:
   # branch-deploy trigger job

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ The source repository for the EDF website
 
 ## Check it Out 🔗
 
-[edf.bean-recordings.com](https://edf.bean-recordings.com)
+[edf.birki.io](https://edf.birki.io)
 
 ![example](src/assets/images/default.png)

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-edf.bean-recordings.com
+edf.birki.io

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow:
 
-Sitemap: https://edf.bean-recordings.com/sitemap-index.xml
+Sitemap: https://edf.birki.io/sitemap-index.xml

--- a/src/config/site/config.js
+++ b/src/config/site/config.js
@@ -7,7 +7,7 @@ const CONFIG = {
   // The name of the website
   name: 'Electronic Dairy Festival',
   // The origin of the website (without trailing slash)
-  origin: 'https://edf.bean-recordings.com',
+  origin: 'https://edf.birki.io',
   // The base pathname of the website
   basePathname: '/',
   // If the website uses trailing slashes in the URLs

--- a/src/content/post/edf-2022-memories.md
+++ b/src/content/post/edf-2022-memories.md
@@ -8,7 +8,7 @@ image: ~/assets/images/poster.png
 tags:
   - '2022'
   - edf
-canonical: https://edf.bean-recordings.com/edf-2022-memories
+canonical: https://edf.birki.io/edf-2022-memories
 ---
 
 ## EDF 2022 🎧

--- a/src/content/post/edf-2023-memories.md
+++ b/src/content/post/edf-2023-memories.md
@@ -8,7 +8,7 @@ image: ~/assets/images/edf-2023.png
 tags:
   - '2023'
   - edf
-canonical: https://edf.bean-recordings.com/edf-2023-memories
+canonical: https://edf.birki.io/edf-2023-memories
 ---
 
 ## EDF 2023 🎧


### PR DESCRIPTION
The domain name is getting reverted back to `edf.birki.io` because the other domain is busted and the _beans_ are DNS 🥔